### PR TITLE
Maple.run() - Better errors

### DIFF
--- a/src/maple/__init__.py
+++ b/src/maple/__init__.py
@@ -330,7 +330,11 @@ def run(*specs: Callable):
     Args:
         *specs: Callable
     """
-    for spec in specs:
+    for i, spec in enumerate(specs):
+        if not callable(spec):
+            raise ValueError(
+                "parameter at position " + f"{i}" + " is not spec function."
+            )
         spec()
 
     # print results

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,9 +1,9 @@
 import maple as mp
+import pytest
 
 
-def test_init():
+def test_success_run():
     stream_id = "24fa0ed1c3"
-    # pass None to force mp to use the stream id to get object
     mp.stream(stream_id)
     mp.run(spec)
     assert mp._stream_id == stream_id
@@ -17,11 +17,15 @@ def test_init():
     return
 
 
+def test_error_run():
+    some = "hello"
+    with pytest.raises(AttributeError):
+        mp.run(some)  # type: ignore
+
+
 def spec():
     mp.it("checks window height is greater than 2600 mm")
 
-    mp.get('category', 'Windows')\
-        .where('speckle_type',
-               'Objects.Other.Instance:Objects.Other.Revit.RevitInstance')\
-        .its('Height')\
-        .should('be.greater', 2600)  # assert
+    mp.get("category", "Windows").where(
+        "speckle_type", "Objects.Other.Instance:Objects.Other.Revit.RevitInstance"
+    ).its("Height").should("be.greater", 2600)  # assert

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -19,7 +19,7 @@ def test_success_run():
 
 def test_error_run():
     some = "hello"
-    with pytest.raises(AttributeError):
+    with pytest.raises(ValueError):
         mp.run(some)  # type: ignore
 
 


### PR DESCRIPTION
Gives a ValueError when the argument of run is not a function with the message "parameter at position N is not a spec function"