### PR TITLE
Mp run - no raise errors

### DIFF
--- a/src/maple/__init__.py
+++ b/src/maple/__init__.py
@@ -332,9 +332,10 @@ def run(*specs: Callable):
     """
     for i, spec in enumerate(specs):
         if not callable(spec):
-            raise ValueError(
-                "parameter at position " + f"{i}" + " is not spec function."
+            print(
+                "Warning - parameter at position " + f"{i}" + " is not spec function."
             )
+            continue
         spec()
 
     # print results

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -19,8 +19,8 @@ def test_success_run():
 
 def test_error_run():
     some = "hello"
-    with pytest.raises(ValueError):
-        mp.run(some)  # type: ignore
+    other = {"name": "i'm a function"}
+    mp.run(spec, some, other)  # type: ignore
 
 
 def spec():


### PR DESCRIPTION
The logic here to not throw an error is that we give the chance to run the other specs that are functions, and not penalize the user for passing a non function.
Additionally there are type hints which will enforce that what is passed is a function