### PR TITLE
#5 improve the test results shown in the console

### DIFF
--- a/examples/specs.py
+++ b/examples/specs.py
@@ -10,55 +10,60 @@ def main():
 def spec_a():
     mp.it("checks window height is greater than 2600 mm")
 
-    mp.get("category", "Windows").where(
-        "speckle_type", "Objects.Other.Instance:Objects.Other.Revit.RevitInstance"
-    ).its("Height").should("be.greater", 2600)  # assert
+    mp.get("category", "Windows")\
+        .where("speckle_type", "Objects.Other.Instance:Objects.Other.Revit.RevitInstance")\
+        .its("Height")\
+        .should("be.greater", 2600)
 
 
 def spec_b():
     mp.it("validates SIP 202mm wall type area is greater than 43 m2")
 
-    mp.get("family", "Basic Wall").where("type", "SIP 202mm Wall - conc clad").its(
-        "Area"
-    ).should("be.greater", 43)
+    mp.get("family", "Basic Wall")\
+        .where("type", "SIP 202mm Wall - conc clad")\
+        .its("Area")\
+        .should("be.greater", 43)
 
 
 def spec_c():
     mp.it("checks pipe radius")
 
-    mp.get("category", "Plumbing Fixtures").its("OmniClass Title").should(
-        "have.value", "Bathtubs"
-    )
+    mp.get("category", "Plumbing Fixtures")\
+        .its("OmniClass Title")\
+        .should("have.value", "Bathtubs")
 
 
 def spec_d():
     mp.it("validates basic roof`s thermal mass")
 
-    mp.get("family", "Basic Roof").where("type", "SG Metal Panels roof").its(
-        "Thermal Mass"
-    ).should("be.equal", 20.512)
+    mp.get("family", "Basic Roof")\
+        .where("type", "SG Metal Panels roof")\
+        .its("Thermal Mass")\
+        .should("be.equal", 20.512)
 
 
 def spec_e():
     mp.it("validates columns assembly type.")
 
-    mp.get("family", "M_Concrete-Round-Column with Drop Caps").its(
-        "Assembly Code"
-    ).should("have.value", "B10")
+    mp.get("family", "M_Concrete-Round-Column with Drop Caps")\
+        .its("Assembly Code")\
+        .should("have.value", "B10")
 
 
 def spec_f():
     mp.it("validates ceiling thickness is 50")
 
-    mp.get("category", "Ceilings").where("type", "3000 x 3000mm Grid").its(
-        "Absorptance"
-    ).should("be.equal", 0.1)
+    mp.get("category", "Ceilings")\
+        .where("type", "3000 x 3000mm Grid")\
+        .its("Absorptance")\
+        .should("be.equal", 0.1)
 
 
 def spec_g():
     mp.it("Checks there are exactly 55 walls")
 
-    mp.get("category", "Walls").should("have.length", 55)
+    mp.get("category", "Walls")\
+        .should("have.length", 55)
 
 
 if __name__ == "__main__":

--- a/examples/specs.py
+++ b/examples/specs.py
@@ -10,58 +10,57 @@ def main():
 def spec_a():
     mp.it("checks window height is greater than 2600 mm")
 
-    mp.get('category', 'Windows')\
-        .where('speckle_type',
-               'Objects.Other.Instance:Objects.Other.Revit.RevitInstance')\
-        .its('Height')\
-        .should('be.greater', 2600)  # assert
+    mp.get("category", "Windows").where(
+        "speckle_type", "Objects.Other.Instance:Objects.Other.Revit.RevitInstance"
+    ).its("Height").should("be.greater", 2600)  # assert
 
 
 def spec_b():
     mp.it("validates SIP 202mm wall type area is greater than 43 m2")
 
-    mp.get('family', 'Basic Wall')\
-        .where('type', 'SIP 202mm Wall - conc clad')\
-        .its('Area')\
-        .should('be.greater', 43)
+    mp.get("family", "Basic Wall").where("type", "SIP 202mm Wall - conc clad").its(
+        "Area"
+    ).should("be.greater", 43)
 
 
 def spec_c():
     mp.it("checks pipe radius")
 
-    mp.get('category', 'Plumbing Fixtures').its(
-        'OmniClass Title').should('have.value', 'Bathtubs')
+    mp.get("category", "Plumbing Fixtures").its("OmniClass Title").should(
+        "have.value", "Bathtubs"
+    )
 
 
 def spec_d():
     mp.it("validates basic roof`s thermal mass")
 
-    mp.get('family', 'Basic Roof')\
-        .where('type', 'SG Metal Panels roof')\
-        .its('Thermal Mass').should('be.equal', 20.512)
+    mp.get("family", "Basic Roof").where("type", "SG Metal Panels roof").its(
+        "Thermal Mass"
+    ).should("be.equal", 20.512)
 
 
 def spec_e():
     mp.it("validates columns assembly type.")
 
-    mp.get('family', 'M_Concrete-Round-Column with Drop Caps').its(
-        'Assembly Code').should('have.value', 'B10')
+    mp.get("family", "M_Concrete-Round-Column with Drop Caps").its(
+        "Assembly Code"
+    ).should("have.value", "B10")
 
 
 def spec_f():
     mp.it("validates ceiling thickness is 50")
 
-    mp.get('category', 'Ceilings')\
-        .where('type',  '3000 x 3000mm Grid')\
-        .its('Absorptance').should('be.equal', 0.1)
+    mp.get("category", "Ceilings").where("type", "3000 x 3000mm Grid").its(
+        "Absorptance"
+    ).should("be.equal", 0.1)
 
 
 def spec_g():
     mp.it("Checks there are exactly 55 walls")
 
-    mp.get('category', 'Walls')\
-        .should('have.length', 55)
+    mp.get("category", "Walls").should("have.length", 55)
 
 
 if __name__ == "__main__":
+    mp.set_logging(False)
     main()

--- a/examples/specs.py
+++ b/examples/specs.py
@@ -62,5 +62,5 @@ def spec_g():
 
 
 if __name__ == "__main__":
-    mp.set_logging(False)
+    mp.set_logging(True)
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 description = "A testing library for Speckle models"
 readme = "README.md"
 requires-python = ">=3.8"
-dependencies = ["specklepy"]
+dependencies = ["specklepy", "importlib-metadata"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3",

--- a/src/maple/__init__.py
+++ b/src/maple/__init__.py
@@ -361,8 +361,9 @@ def log_to_stdout(*args):
 
 def print_info(specs):
     from importlib_metadata import version
+    from .utils import print_title
 
-    print("=================== Test session ======================")
+    print_title("Test session")
 
     v = version("maple-spec")
     print("Maple -", v)

--- a/src/maple/__init__.py
+++ b/src/maple/__init__.py
@@ -18,6 +18,7 @@ from .models import Result, Assertion
 _test_cases: list[Result] = []  # Contains the results of the runs
 _current_object: Base | None = None
 _stream_id: str = ""
+_log_out: bool = True
 
 
 def init(obj: Base) -> None:
@@ -27,6 +28,17 @@ def init(obj: Base) -> None:
     global _current_object
     _current_object = obj
     return
+
+
+def set_logging(f: bool) -> None:
+    """
+    Set log to std out. Default is True
+
+    Args:
+        f: bool
+    """
+    global _log_out
+    _log_out = f
 
 
 def stream(id: str) -> None:
@@ -179,7 +191,7 @@ class Chainable:
         Raises: ValueError if comparer is not a defined CompOp
         Returns: Chainable
         """
-        print("Asserting - should:", comparer, assertion_value)
+        log_to_stdout("Asserting - should:", comparer, assertion_value)
         comparer_op = CompOp(comparer)
         self.assertion.value = assertion_value
         self.assertion.comparer = comparer_op
@@ -202,7 +214,7 @@ class Chainable:
             AttributeError: if the parameter name does not match in the
             inner object selected with get
         """
-        print("Selecting", property)
+        log_to_stdout("Selecting", property)
         self.selector = property
 
         objs = self.content
@@ -236,14 +248,14 @@ class Chainable:
 
         Returns: Chainable
         """
-        print("Filtering by:", selector, value)
+        log_to_stdout("Filtering by:", selector, value)
         current = get_current_test_case()
         current.selected[selector] = value
 
         selected = list(
             filter(lambda obj: property_equal(selector, value, obj), self.content)
         )
-        print("Got", len(selected))
+        log_to_stdout("Got", len(selected))
         self.content = selected
         return self
 
@@ -258,8 +270,8 @@ def it(spec_name: str):
 
     Returns: None
     """
-    print("-------------------------------------------------------")
-    print("Running test:", spec_name)
+    log_to_stdout("-------------------------------------------------------")
+    log_to_stdout("Running test:", spec_name)
     get_test_cases().append(Result(spec_name))
 
 
@@ -280,7 +292,7 @@ def get(selector: str, value: str) -> Chainable:
         Exception: If it was not possible to query a speckle object
     """
 
-    print("Getting", selector, value)
+    log_to_stdout("Getting", selector, value)
     current_test = get_current_test_case()
     current_test.selected[selector] = value
 
@@ -293,7 +305,7 @@ def get(selector: str, value: str) -> Chainable:
     objs = list(flatten_base(speckle_obj))
 
     selected = list(filter(lambda obj: property_equal(selector, value, obj), objs))
-    print("Got", len(selected), value)
+    log_to_stdout("Got", len(selected), value)
 
     return Chainable(selected)
 
@@ -327,6 +339,8 @@ def run(*specs: Callable):
     Args:
         *specs: Callable
     """
+    print_info(specs)
+
     for i, spec in enumerate(specs):
         if not callable(spec):
             print(
@@ -337,3 +351,20 @@ def run(*specs: Callable):
 
     # print results
     print_results(get_test_cases())
+
+
+def log_to_stdout(*args):
+    global _log_out
+    if _log_out:
+        print("INFO:", *args)
+
+
+def print_info(specs):
+    from importlib_metadata import version
+
+    print("=================== Test session ======================")
+
+    v = version("maple-spec")
+    print("Maple -", v)
+    print("collected", len(specs), "specs")
+    print()

--- a/src/maple/utils.py
+++ b/src/maple/utils.py
@@ -37,4 +37,4 @@ def print_results(test_cases: list[Result]):
                 row.append(GREEN + "Passed" + ENDC)
             table.append(row)
     for row in table:
-        print("| {:^60} | {:<6} |".format(*row))
+        print("| {:<60} | {:<6} |".format(*row))

--- a/src/maple/utils.py
+++ b/src/maple/utils.py
@@ -1,18 +1,40 @@
 from .models import Result
 
 
+RED = "\033[1;31m"
+BLUE = "\033[1;34m"
+CYAN = "\033[1;36m"
+GREEN = "\033[0;32m"
+RESET = "\033[0;0m"
+BOLD = "\033[;1m"
+REVERSE = "\033[;7m"
+ENDC = "\033[0m"
+
+
+def print_title(text: str):
+    character = "="
+    max_length = 73
+    padded = f" {text} "
+    n = int((max_length - len(padded)) / 2)
+    print(f"{character*n}{padded}{character*n}")
+
+
 def print_results(test_cases: list[Result]):
     """
     Prints results to std-out
     """
-    print("=================== Test Results ======================")
+
+    print_title("Test results")
     print()
+    table = []
     for case in test_cases:
-        print(case.spec_name, end="")
         assertions = case.assertions
         for assertion in assertions:
+            row = [case.spec_name]
             if len(assertion.failing) > 0:
-                print(" - Failed")
-                # print(">> ids:", assertion.failed)
+                row.append(RED + "Failed" + ENDC)
             else:
-                print(" - Passed")
+                row.append(GREEN + "Passed" + ENDC)
+            table.append(row)
+    for row in table:
+        print("| {:^60} | {:<6} |".format(*row))

--- a/src/maple/utils.py
+++ b/src/maple/utils.py
@@ -5,9 +5,8 @@ def print_results(test_cases: list[Result]):
     """
     Prints results to std-out
     """
-    print("-------------------------------------------------------")
-    print("---RESULTS---")
-    print("-------------------------------------------------------")
+    print("=================== Test Results ======================")
+    print()
     for case in test_cases:
         print(case.spec_name, end="")
         assertions = case.assertions


### PR DESCRIPTION
solves: #5 

This PR separates logging from test results and improves the appearance of the output of results

The information related to what's being queried, selected, asserted, goes to `log_to_stdout()` where its printed with the prefix "INFO".

The information related to the results of the test is printed at the end in a table format:

![image](https://github.com/andrsbtrg/maple/assets/63083862/757137bd-5044-4ac9-b125-54fee15ca00d)

At the beginning of the test session, maple will print the number of specs received as well as the library version:

![image](https://github.com/andrsbtrg/maple/assets/63083862/1f1c7392-601a-492f-93f8-bfcf30de6e66)

To get the current library version, this PR adds the external package `importlib-metadata`
