### PR TITLE
Fix: not reusing the base object during the same test

### DIFF
--- a/src/maple/__init__.py
+++ b/src/maple/__init__.py
@@ -81,6 +81,21 @@ def get_current_obj() -> Base | None:
     return _current_object
 
 
+def set_current_obj(obj: Base) -> None:
+    """
+    Caches a speckle object in the global _current_object
+    so it can be reused in the next tests
+
+    Args:
+        obj: a speckle Base object
+
+    Returns: None
+    """
+    global _current_object
+    _current_object = obj
+    return
+
+
 def get_current_test_case() -> Result:
     """
     Get the current test case
@@ -314,6 +329,7 @@ def get_last_obj() -> Base:
     """
     Gets the last object for the specified stream_id
     """
+    log_to_stdout("Getting object from speckle")
     client = SpeckleClient(host="https://latest.speckle.systems")
     # authenticate the client with a token
     account = get_default_account()
@@ -330,6 +346,9 @@ def get_last_obj() -> Base:
     if not last_obj_id:
         raise Exception("No object_id")
     last_obj = operations.receive(obj_id=last_obj_id, remote_transport=transport)
+
+    # cache the current obj
+    set_current_obj(last_obj)
     return last_obj
 
 

--- a/src/maple/__init__.py
+++ b/src/maple/__init__.py
@@ -49,10 +49,17 @@ def set_logging(f: bool) -> None:
 
 def stream(id: str) -> None:
     """
-    Set the stream_id
+    Sets the current stream_id to be used to query the base object
+
+    Args:
+        id: a speckle stream (project) id
+
+    Returns: None
     """
     global _stream_id
     _stream_id = id
+    global _current_object
+    _current_object = None
     return
 
 

--- a/src/maple/__init__.py
+++ b/src/maple/__init__.py
@@ -23,7 +23,13 @@ _log_out: bool = True
 
 def init(obj: Base) -> None:
     """
-    Sets the obj as current object
+    Caches the speckle object obj in the global _current_object
+    so it can be reused in the next tests
+
+    Args:
+        obj: a speckle Base object
+
+    Returns: None
     """
     global _current_object
     _current_object = obj
@@ -79,21 +85,6 @@ def get_current_obj() -> Base | None:
     """
     global _current_object
     return _current_object
-
-
-def set_current_obj(obj: Base) -> None:
-    """
-    Caches a speckle object in the global _current_object
-    so it can be reused in the next tests
-
-    Args:
-        obj: a speckle Base object
-
-    Returns: None
-    """
-    global _current_object
-    _current_object = obj
-    return
 
 
 def get_current_test_case() -> Result:
@@ -270,7 +261,7 @@ class Chainable:
         selected = list(
             filter(lambda obj: property_equal(selector, value, obj), self.content)
         )
-        log_to_stdout("Got", len(selected))
+        log_to_stdout("Elements after filter:", len(selected))
         self.content = selected
         return self
 
@@ -348,7 +339,7 @@ def get_last_obj() -> Base:
     last_obj = operations.receive(obj_id=last_obj_id, remote_transport=transport)
 
     # cache the current obj
-    set_current_obj(last_obj)
+    init(last_obj)
     return last_obj
 
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -22,6 +22,19 @@ def test_error_run():
     mp.run(spec, some, other)  # type: ignore
 
 
+def test_multiple_streams():
+    stream_id = "24fa0ed1c3"
+    mp.stream(stream_id)
+    mp.run(spec)
+
+    # We set the stream id to another, it doesn't
+    # matter that is not valid since we will not use it to query
+    mp.stream("other")
+
+    # Setting the stream should reset the current object
+    assert mp.get_current_obj() is None
+
+
 def spec():
     min_height = 900
     mp.it(f"checks window height is greater than {min_height} mm")


### PR DESCRIPTION

### Reference to related issue

Related Issue #

### What was added/changed?

Caching the base object received from get(...) so that it can be used in the next specs, this reduces the time to test n specs by the number of specs n.

  
### Why was it added/changed?

It was unnecessary that for every spec we again query the base object, if we already queried it once we can reuse it in the next spec assertion and save time.

### Technical implementation

After we get the current object from speckle we cache it with `init(current_obj)`. We were already using the global `_current_obj` to cache the base object when we are running on the speckle-automate function. 

### Acceptance criteria

- [x] Running 5 specs on the same stream id should only query the speckle object once
- [x] Cached base object should be reset when the user sets a new stream_id

### Checklist before requesting review

- [x] Documentation was expanded
- [x] Acceptance criteria are met
- [x] The function was tested by unit tests

### Checklist for reviewers

- [ ] Code checked
- [ ] Acceptance criteria are met
