### PR TITLE
Update dependecy of specklepy to temporary own version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "maple-spec"
-version = "0.0.6"
+version = "0.0.7"
 authors = [
   { name="Gizem Demirhan", email="gizemdemirhaan@gmail.com" },
   { name="Andres Buitrago", email="andrsbtrg@gmail.com" }
@@ -12,7 +12,7 @@ authors = [
 description = "A testing library for Speckle models"
 readme = "README.md"
 requires-python = ">=3.8"
-dependencies = ["specklepy", "importlib-metadata", "jinja2"]
+dependencies = ["specklepy@git+https://github.com/Gizemdem/specklepy", "importlib-metadata", "jinja2"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
### Reference to related issue

Related Issue : maple-cloud "#9"

### What was added/changed?

 Using specklepy as our own dependecy temporarily. This specklepy dependecy is a pure python package

### Why was it added/changed?

This was added so we can test having a pure python package with pyodide

### Technical implementation

Changing the path of the dependency in pyproject.toml

### Acceptance criteria

- [x] Test run and pass

### Checklist before requesting review

- [ ] Documentation was expanded
- [x] Acceptance criteria are met
- [x] The function was tested by unit tests

### Checklist for reviewers

- [ ] Code checked
- [ ] Acceptance criteria are met
