### PR TITLE
Test against properties outside of Parameters

### DIFF
--- a/examples/multiple_specs.py
+++ b/examples/multiple_specs.py
@@ -4,7 +4,7 @@ import maple as mp
 
 def main():
     stream_id = "24fa0ed1c3"
-    mp.stream(stream_id)
+    mp.init_model(project_id=stream_id, model_id="2696b4a381")
     mp.set_logging(True)
     mp.run(spec_a, spec_b, spec_c, spec_d, spec_e, spec_f, spec_g)
     mp.generate_report(".")

--- a/examples/single_spec.py
+++ b/examples/single_spec.py
@@ -1,0 +1,19 @@
+import setup  # noqa
+import maple as mp
+
+
+def main():
+    mp.init_model(project_id="62bd771c0e", model_id="28e03dc3c7")
+    mp.set_logging(True)
+    mp.run(test_check_door_height)
+    mp.generate_report(output_path=".")
+
+
+def test_check_door_height():
+    mp.it("Checks that the door height its at least 2.0 m")
+
+    mp.get("type", "IFCDOOR").its("OverallHeight").should("be.greater", 2.0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/maple/__init__.py
+++ b/src/maple/__init__.py
@@ -175,7 +175,7 @@ class Chainable:
         objs = self.content
         # check on base object
         for obj in objs:
-            prop = getattr(obj, parameter_name)
+            prop = getattr(obj, parameter_name, None)
             if not prop:
                 break
             parameter_values.append(prop)
@@ -283,7 +283,7 @@ class Chainable:
         objs = self.content
         # check on base object
         for obj in objs:
-            props = getattr(obj, property)
+            props = getattr(obj, property, None)
             if not props:
                 break
             return self

--- a/src/maple/__init__.py
+++ b/src/maple/__init__.py
@@ -173,6 +173,17 @@ class Chainable:
         """
         parameter_values = []
         objs = self.content
+        # check on base object
+        for obj in objs:
+            prop = getattr(obj, parameter_name)
+            if not prop:
+                break
+            parameter_values.append(prop)
+
+        if len(parameter_values) > 0:
+            return parameter_values
+
+        # check in parameters
         for obj in objs:
             parameters = getattr(obj, "parameters")
             if parameters is None:
@@ -270,6 +281,14 @@ class Chainable:
         self.assertion.selector = property
 
         objs = self.content
+        # check on base object
+        for obj in objs:
+            props = getattr(obj, property)
+            if not props:
+                break
+            return self
+
+        # check inside parameters
         for obj in objs:
             parameters = getattr(obj, "parameters")
             if parameters is None:

--- a/src/maple/__init__.py
+++ b/src/maple/__init__.py
@@ -51,6 +51,9 @@ def set_logging(f: bool) -> None:
     _log_out = f
 
 
+@deprecated(
+    reason="Starting with maple 0.1 please use mp.init_model to specify a project and model id."
+)
 def stream(id: str) -> None:
     """
     Sets the current stream_id to be used to query the base object

--- a/src/maple/__init__.py
+++ b/src/maple/__init__.py
@@ -1,3 +1,4 @@
+from deprecated import deprecated
 from typing_extensions import Self, Callable
 from typing import Any
 from specklepy.api.client import SpeckleClient
@@ -5,6 +6,7 @@ from specklepy.api.credentials import get_default_account
 from specklepy.api import operations
 from specklepy.transports.server.server import ServerTransport
 from specklepy.objects import Base
+from specklepy.core.api.models import Branch
 
 # maple imports
 from .base_extensions import flatten_base
@@ -19,6 +21,7 @@ from .report import HtmlReport
 _test_cases: list[Result] = []  # Contains the results of the runs
 _current_object: Base | None = None
 _stream_id: str = ""
+_model_id: str = ""
 _log_out: bool = True
 
 
@@ -64,6 +67,26 @@ def stream(id: str) -> None:
     return
 
 
+def init_model(project_id: str, model_id: str) -> None:
+    """
+    Sets the global variables project id and model id for the
+    current test until reset.
+
+
+    Args:
+        project_id: a project id
+        model_id: the model id to test
+
+    """
+    global _stream_id
+    _stream_id = project_id
+    global _model_id
+    _model_id = model_id
+    global _current_object
+    _current_object = None
+    return
+
+
 def get_token():
     """
     Get the token to authenticate with Speckle.
@@ -85,6 +108,16 @@ def get_stream_id() -> str:
     if _stream_id == "":
         raise Exception("Please provide a Stream id using mp.stream()")
     return _stream_id
+
+
+def get_model_id() -> str:
+    """
+    Gets the Model id provided with mp.init_model
+    """
+    global _model_id
+    if _model_id == "":
+        raise Exception("Please provide a Model Id to test using mp.init_model()")
+    return _model_id
 
 
 def get_current_obj() -> Base | None:
@@ -341,9 +374,25 @@ def get_last_obj() -> Base:
         client.authenticate_with_token(token)
 
     stream_id = get_stream_id()
+    model_id = get_model_id()
     transport = ServerTransport(client=client, stream_id=stream_id)
 
-    last_obj_id = client.commit.list(stream_id)[0].referencedObject
+    branches: list[Branch] = client.branch.list(stream_id)
+    if len(branches) == 0:
+        raise Exception("Project contains no models.")
+    if type(branches[0]) is not Branch:
+        raise Exception("Expected list of branches")
+    branch = list(filter(lambda branch: branch.id == model_id, branches))
+
+    if len(branch) == 0:
+        raise Exception("Model id was not found.")
+
+    versions = branch[0].commits
+    if versions is None:
+        raise Exception("Current model has no versions.")
+
+    last_obj_id = versions.items[0].referencedObject
+
     if not last_obj_id:
         raise Exception("No object_id")
     last_obj = operations.receive(obj_id=last_obj_id, remote_transport=transport)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -3,7 +3,7 @@ import maple as mp
 
 def test_success_run():
     stream_id = "24fa0ed1c3"
-    mp.stream(stream_id)
+    mp.init_model(project_id=stream_id, model_id="2696b4a381")
     mp.run(spec)
     assert mp._stream_id == stream_id
     test_case = mp.get_current_test_case()
@@ -24,12 +24,12 @@ def test_error_run():
 
 def test_multiple_streams():
     stream_id = "24fa0ed1c3"
-    mp.stream(stream_id)
+    mp.init_model(project_id=stream_id, model_id="2696b4a381")
     mp.run(spec)
 
     # We set the stream id to another, it doesn't
     # matter that is not valid since we will not use it to query
-    mp.stream("other")
+    mp.init_model("other", "rehto")
 
     # Setting the stream should reset the current object
     assert mp.get_current_obj() is None


### PR DESCRIPTION
### Reference to related issue

Related Issue:
Fixes #13 and solves  #12 

### What was added/changed?

- Adds a public method to specify a model id, related to #12 . Updates tests accordingly to use maple.init_model(), instead of maple.stream
- Marks function mp.stream as deprecated
- Now we can check against attributes of the object instead of only the parameters. Added an example for this in examples/single_spec.py
  
### Why was it added/changed?

Initially we where only focused on testing revit models, so it made sense to only check inside the object "parameters" object. But as the library grows we will want to have more flexibility to check against other properties inside of the object.

### Technical implementation

 - use getattr(obj, parameter_name, default) to check if the value we are checking exists, before looping through the parameters. For example if we specify its('Height') it will first check via `getattr(obj, "Height", None) and if not found it will continue and check inside the parameters.

### Acceptance criteria

- [x] Tests are passing
- [x] New API means examples are updated
- [x] Deprecated functions should be marked as so

### Checklist before requesting review

- [x] Documentation was expanded
- [x] Acceptance criteria are met
- [x] The function was tested by unit tests

### Checklist for reviewers

- [ ] Code checked
- [ ] Acceptance criteria are met
