### PR TITLE
15 bug reporthtml template is not included in python package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=61.0", "setuptools-scm>=8.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -28,3 +28,9 @@ Issues = "https://github.com/andrsbtrg/maple/issues"
 pythonpath = [
   "src"
 ]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+mypkg = ["*.html"]

--- a/src/maple/report.py
+++ b/src/maple/report.py
@@ -10,7 +10,7 @@ class HtmlReport:
         self.template_file = "report.html"
         return
 
-    def create(self, output_path: str) -> int:
+    def create(self, output_path: str) -> str:
         """
         Generates a HTML report at the output_path directory.
 
@@ -31,4 +31,5 @@ class HtmlReport:
         filename = f"maple_report_{time}.html"
         output_path = os.path.join(output_path, filename)
         with open(output_path, "w") as file:
-            return file.write(output)
+            file.write(output)
+        return output_path

--- a/src/maple/report.py
+++ b/src/maple/report.py
@@ -1,7 +1,7 @@
 from time import strftime
 import os
 from .models import Result
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, PackageLoader
 
 
 class HtmlReport:
@@ -22,7 +22,7 @@ class HtmlReport:
             int: number of bytes written
         """
 
-        file_loader = FileSystemLoader("src/maple/templates")
+        file_loader = PackageLoader("maple")
         env = Environment(loader=file_loader)
         template = env.get_template(self.template_file)
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,3 +1,4 @@
+from os import path
 import maple as mp
 from maple import HtmlReport
 
@@ -7,5 +8,7 @@ def test_report(tmp_path):
     dir.mkdir()
     results = mp.get_test_cases()
     report = HtmlReport(results)
-    bytes_written = report.create(dir)
-    assert bytes_written != 0
+    output_path = report.create(dir)
+    assert path.exists(output_path)
+    with open(output_path) as file:
+        assert file.read() != ""


### PR DESCRIPTION
### Reference to related issue

Related Issue #15 

### What was added/changed?

We include html files explicitely in the pyproject.toml file
We use the PackageLoader form jinja instead of FileSystemLoader to locate the html template file and use it.
  
### Why was it added/changed?

To fix a bug where we are unable to generate reports

### Technical implementation

### Acceptance criteria

- [x] Add test

### Checklist before requesting review

- [x] Documentation was expanded
- [x] Acceptance criteria are met
- [x] The function was tested by unit tests

### Checklist for reviewers

- [ ] Code checked
- [ ] Acceptance criteria are met
